### PR TITLE
Add a versioning tool for Windows users

### DIFF
--- a/version.bat
+++ b/version.bat
@@ -1,0 +1,1 @@
+powershell -executionpolicy bypass -File .\version_data.ps1

--- a/version_data.ps1
+++ b/version_data.ps1
@@ -1,0 +1,24 @@
+# Original bash format: {"version": VERSION,"repository": REPO,"branch": CURRENT,"is_dirty": T/F}
+
+# Git commands
+# Problem: Powershell has silently removed -NoNewline from Out-String, trim manually
+[String]$mw_version = (git describe 2> $null) | Out-String
+[String]$mw_repo = (git config --get remote.origin.url 2> $null) | Out-String
+[String]$mw_branch = (git branch 2> $null) | Select-String -Pattern '[*]'
+[String]$mw_current = $mw_branch.replace("* ","")
+[String]$mw_changes = (git diff --quiet)
+
+# Build the output string
+[String]$v_string = '{"version": '
+$v_string += if ($mw_version) { '"' + $mw_version.Trim() + '"' } else { 'None' }
+$v_string += ',"repository": '
+$v_string += if ($mw_repo) { '"' + $mw_repo.Trim() + '"' } else { 'None' }
+$v_string += ',"branch": '
+$v_string += if ($mw_current) { '"' + $mw_current.Trim() + '"' } else { 'None' }
+$v_string += ',"is_dirty": '
+$v_string += if ($mw_changes) { 'true' } else { 'false' }
+$v_string += '}'
+
+# Kill any new-lines that made it through
+$v_out = $v_string.replace("`n","").replace("`r","")
+$v_out| Out-File -Encoding ascii -FilePath version.txt


### PR DESCRIPTION
Windows users cannot currently version the data and therefore create a valid JSON entry with which to run the model. The two new files are a batch script (to be executed by the user) and a PowerShell script (to exploit the better programming available compared with the CMD prompt). Running version.bat will execute version_data.ps1 with PowerShell to call the git commands just like the original bash script. Execution policies in PowerShell are bypassed just once, so there are no persistent changes to the security settings.